### PR TITLE
fix: download the right episodes when downloading the whole season

### DIFF
--- a/vvvvid_downloader/__main__.py
+++ b/vvvvid_downloader/__main__.py
@@ -103,7 +103,7 @@ def main(download: bool) -> None:
         show_title = i.show_title
         episode_number = i.number
 
-        embed_code = getattr(season[0], quality_code, "")
+        embed_code = getattr(i, quality_code, "")
         output_dir = Path().joinpath("vvvvid", show_title)
         output_name = re_sub(r"\s", "_", f"{show_title}_Ep_{episode_number}_{quality}")
 


### PR DESCRIPTION
Hi, This pull request addresses an issue in the VVVVID Downloader script, where it would always download the first episode (s01e01) when attempting to download all episodes. The problem was caused by the script using the first episode in the season list to obtain the embed code, regardless of the current episode in the loop.